### PR TITLE
ci(publish): security update at publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,10 +5,6 @@ on:
     types: [published, prereleased]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: write
-
 jobs:
   publish:
     name: Upload release to PyPI
@@ -18,6 +14,7 @@ jobs:
       url: https://pypi.org/project/spacy-ewc/
     permissions:
       contents: read
+      packages: write
       id-token: write # Required for OIDC authentication
 
     steps:


### PR DESCRIPTION
### Description

Restrict 'packages: write' permission to publish job in publish.yml

- Set top-level permissions to 'contents: read' to follow the principle of least privilege.
- Scoped 'packages: write' permission to the 'publish' job to reduce security risks.
- Align workflow with GitHub's recommended security best practices.

- **Related Issue**: Closes #9 
- **Type of Change**:  
  - Bug fix (non-breaking change that fixes an issue)

### Checklist

Please ensure the following guidelines are met:

- [x] The code follows the style guidelines of this project.
- [x] A self-review has been performed on the code.
- [x] The code is well-documented, and comments have been added where necessary.
- [x] Tests have been added to prove that the fix is effective or that the feature works. All existing tests pass.
- [x] Commit messages follow the convention `type(scope): description`.
- [x] The pull request has no conflicts with the base branch.
- [x] Any dependent changes have been merged and published in downstream modules.

### Additional Information

Please provide any additional information or context here. If applicable, add screenshots to help explain the changes.

